### PR TITLE
fix(unsplash): unsplash changing bg ignoring config

### DIFF
--- a/src/plugins/backgrounds/unsplash/Unsplash.tsx
+++ b/src/plugins/backgrounds/unsplash/Unsplash.tsx
@@ -211,6 +211,12 @@ type RotatingCache<Item> = {
   deps: unknown[];
 };
 
+function arrayEquals(a: any[], b: any[]): boolean {
+  return (
+    a.length === b.length && a.every((element, index) => element === b[index])
+  );
+}
+
 /**
  * Implementation adapted from react's hook source.
  * Too bad they do not export it.
@@ -218,6 +224,15 @@ type RotatingCache<Item> = {
 function areDepsEqual(prevDeps: unknown[], nextDeps: unknown[]) {
   for (let i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
     if (Object.is(nextDeps[i], prevDeps[i])) {
+      continue;
+    }
+    // if nextdeps and prevdeps are arrays, compare them via separate func
+    // because Object.is doesn't work for arrays
+    else if (
+      Array.isArray(nextDeps[i]) &&
+      Array.isArray(prevDeps[i]) &&
+      arrayEquals(nextDeps[i] as any[], prevDeps[i] as any[])
+    ) {
       continue;
     }
     return false;


### PR DESCRIPTION
## Subtitle of PR

PR to fix #161 
This fixes whenever a new tab opened or page refreshed app sets new background 1-3 times completely ignoring current configuration
Also this bug can be found even on https://tab-nine.xsfs.xyz/ (every page refresh background changes)

## Checklist

### Developer Testing Evidence

Evidence of the PR is in action in the section below.

- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Edge

## Evidence

### Chrome

### Firefox

[Evidence](https://imgur.com/a/IVzsxUb)

### Edge
