### PR TITLE
add kagi to engines ts

### DIFF
--- a/src/plugins/widgets/search/engines.ts
+++ b/src/plugins/widgets/search/engines.ts
@@ -87,4 +87,9 @@ export const engines: Engine[] = [
     name: "Phind",
     search_url: "https://phind.com/search?q={searchTerms}",
   },
+  {
+    key: "kagi",
+    name: "Kagi",
+    search_url: "https://kagi.com/search?q={searchTerms}"
+  },
 ];


### PR DESCRIPTION
## Add Kagi search to engines.ts

Add the human-first, privacy forcused Kagi search engine to engines.ts

## Checklist

### Developer Testing Evidence

Evidence of the PR is in action in the section below.

- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Edge

## Evidence

### Tested on

- Chromium Version 120.0.6099.71
- Firefox 122.0.1 (64-Bit)
- Edge Version 121.0.2277.106 (Official build) (64-bit)

### Chrome

https://github.com/the-wright-jamie/tab-nine/assets/24294933/dbd9e29e-36d8-4b56-b49b-503d79ad3e27

### Firefox

https://github.com/the-wright-jamie/tab-nine/assets/24294933/185ed1cf-e991-4038-8af0-3885921c4ca2

### Edge

https://github.com/the-wright-jamie/tab-nine/assets/24294933/267dbdc9-93a4-464a-8bc5-859060708bf8
