### PR TITLE
fix grabbing favicons

### DIFF
--- a/src/plugins/widgets/links/Display.tsx
+++ b/src/plugins/widgets/links/Display.tsx
@@ -62,7 +62,7 @@ const Display: FC<Props> = ({ icon, name, number, url, linkOpenStyle }) => {
           <i>
             <img
               alt={domain}
-              src={`https://icons.duckduckgo.com/ip3/${domain}.ico`}
+              src={`https://www.google.com/s2/favicons?sz=32&domain_url=${domain}`}
             />
           </i>
         ) : null


### PR DESCRIPTION
The duckduckgo favicon grabber is not working for links with subdomains, resulting in broken icons. So I have used google's utility instead.

Eg:

https://icons.duckduckgo.com/ip3/https://music.youtube.com/

https://www.google.com/s2/favicons?sz=180&domain_url=https://music.youtube.com/


this commit referenced at https://github.com/joelshepherd/tabliss/pull/666/commits/dad52ed9edfe41c6e2968aa1890553e2c922dfc2

## Subtitle of PR

Brief description of the change.

{Please delete everything in curly brackets like this}

## Checklist

### Developer Testing Evidence

Evidence of the PR is in action in the section below.

- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Edge

## Evidence

{Please include browser version for each. Screenshots or videos are acceptable}

### Chrome

### Firefox

### Edge
